### PR TITLE
Fix random failures of nobubo

### DIFF
--- a/nobubo/assembly.py
+++ b/nobubo/assembly.py
@@ -65,7 +65,7 @@ def _assemble(input_properties: core.InputProperties,
     file_content = [
         "\\batchmode\n",
         "\\documentclass[a4paper,]{article}\n",
-        f"\\usepackage[papersize={{{collage_width}pt,{collage_height}pt}}]{{geometry}}\n",  # include vars
+        f"\\usepackage[papersize={{{collage_width}pt,{collage_height}pt}}]{{geometry}}\n",
         "\\usepackage[utf8]{inputenc}\n",
         "\\usepackage{pdfpages}\n",
         "\\begin{document}\n",
@@ -74,15 +74,14 @@ def _assemble(input_properties: core.InputProperties,
     ]
 
     input_filepath = temp_output_dir / "texfile.tex"
-    output_filename = f"output_{calc.generate_random_string()}.pdf"
-    output_filepath = temp_output_dir / output_filename
+    output_filename = f"output_{calc.generate_random_string()}"
 
     with input_filepath.open("w") as f:  # pathlib has its own open method
         f.writelines(file_content)
 
     command = ["pdflatex",
                "-interaction=nonstopmode",
-               f"-jobname={output_filename.rstrip('.pdf') }",
+               f"-jobname={output_filename}",
                f"-output-directory={temp_output_dir}",
                input_filepath]
 
@@ -91,7 +90,7 @@ def _assemble(input_properties: core.InputProperties,
     except subprocess.CalledProcessError as e:
         print(f"Error while calling pdflatex:\n{e.output}")
 
-    return output_filepath
+    return temp_output_dir / pathlib.Path(output_filename).with_suffix(".pdf")
 
 
 

--- a/tests/test_blackbox.py
+++ b/tests/test_blackbox.py
@@ -8,7 +8,10 @@ def test_no_overview_normal_collage(testdata, tmp_path, pdftester):
     output_filepath = tmp_path / "mock.pdf"
     runner = CliRunner()
     result = runner.invoke(nobubo.main, ["--il", "0", "8", "4", str(filepath), str(output_filepath)])
-    assert result.exit_code == 0
+    try:
+        assert result.exit_code == 0
+    except AssertionError:
+        print(result.output)
     assert pdftester.read() == ["mock_1.pdf"]
 
     assert pdftester.pagecount("mock_1.pdf") == 1
@@ -23,7 +26,10 @@ def test_no_overview_reverse_collage(testdata, tmp_path, pdftester):
     output_filepath = tmp_path / "mock.pdf"
     runner = CliRunner()
     result = runner.invoke(nobubo.main, ["--il", "0", "8", "4", "--reverse", str(filepath), str(output_filepath)])
-    assert result.exit_code == 0
+    try:
+        assert result.exit_code == 0
+    except AssertionError:
+        print(result.output)
     assert pdftester.read() == ["mock_1.pdf"]
 
     assert pdftester.pagecount("mock_1.pdf") == 1
@@ -37,7 +43,10 @@ def test_one_overview_normal_collage(testdata, tmp_path, pdftester):
     output_filepath = tmp_path / "mock.pdf"
     runner = CliRunner()
     result = runner.invoke(nobubo.main, ["--il", "1", "8", "4", str(filepath), str(output_filepath)])
-    assert result.exit_code == 0
+    try:
+        assert result.exit_code == 0
+    except AssertionError:
+        print(result.output)
     assert pdftester.read() == ["mock_1.pdf"]
 
     assert pdftester.pagecount("mock_1.pdf") == 1
@@ -52,7 +61,10 @@ def test_one_overview_reverse_collage(testdata, tmp_path, pdftester):
     output_filepath = tmp_path / "mock.pdf"
     runner = CliRunner()
     result = runner.invoke(nobubo.main, ["--il", "1", "8", "4", "--reverse", str(filepath), str(output_filepath)])
-    assert result.exit_code == 0
+    try:
+        assert result.exit_code == 0
+    except AssertionError:
+        print(result.output)
     assert pdftester.read() == ["mock_1.pdf"]
 
     assert pdftester.pagecount("mock_1.pdf") == 1
@@ -67,7 +79,10 @@ def test_two_overviews_normal_collage(testdata, tmp_path, pdftester):
     output_filepath = tmp_path / "mock.pdf"
     runner = CliRunner()
     result = runner.invoke(nobubo.main, ["--il", "1", "8", "4", "--il", "34", "7", "3", str(filepath), str(output_filepath)])
-    assert result.exit_code == 0
+    try:
+        assert result.exit_code == 0
+    except AssertionError:
+        print(result.output)
     assert pdftester.read() == ["mock_1.pdf", "mock_2.pdf"]
 
     assert pdftester.pagecount("mock_1.pdf") == 1
@@ -85,7 +100,10 @@ def test_two_overviews_reverse_collage(testdata, tmp_path, pdftester):
     output_filepath = tmp_path / "mock.pdf"
     runner = CliRunner()
     result = runner.invoke(nobubo.main, ["--il", "1", "8", "4", "--il", "34", "7", "3", "--reverse", str(filepath), str(output_filepath)])
-    assert result.exit_code == 0
+    try:
+        assert result.exit_code == 0
+    except AssertionError:
+        print(result.output)
     assert pdftester.read() == ["mock_1.pdf", "mock_2.pdf"]
 
     assert pdftester.pagecount("mock_1.pdf") == 1
@@ -103,7 +121,10 @@ def test_one_overview_normal_a0(testdata, tmp_path, pdftester):
     output_filepath = tmp_path / "mock.pdf"
     runner = CliRunner()
     result = runner.invoke(nobubo.main, ["--il", "1", "8", "4", "--ol", "a0", str(filepath), str(output_filepath)])
-    assert result.exit_code == 0
+    try:
+        assert result.exit_code == 0
+    except AssertionError:
+        print(result.output)
     assert pdftester.read() == ["mock_1.pdf"]
 
     assert pdftester.pagecount("mock_1.pdf") == 2
@@ -119,7 +140,10 @@ def test_one_overview_reverse_a0(testdata, tmp_path, pdftester):
     output_filepath = tmp_path / "mock.pdf"
     runner = CliRunner()
     result = runner.invoke(nobubo.main, ["--il", "0", "8", "4", "--ol", "a0", "--reverse", str(filepath), str(output_filepath)])
-    assert result.exit_code == 0
+    try:
+        assert result.exit_code == 0
+    except AssertionError:
+        print(result.output)
     assert pdftester.read() == ["mock_1.pdf"]
 
     assert pdftester.pagecount("mock_1.pdf") == 2
@@ -135,7 +159,10 @@ def test_one_overview_normal_custom(testdata, tmp_path, pdftester):
     output_filepath = tmp_path / "mock.pdf"
     runner = CliRunner()
     result = runner.invoke(nobubo.main, ["--il", "1", "8", "4", "--ol", "920x1187", str(filepath), str(output_filepath)])
-    assert result.exit_code == 0
+    try:
+        assert result.exit_code == 0
+    except AssertionError:
+        print(result.output)
     assert pdftester.read() == ["mock_1.pdf"]
 
     assert pdftester.pagecount("mock_1.pdf") == 4
@@ -153,7 +180,10 @@ def test_two_overviews_normal_a0(testdata, tmp_path, pdftester):
     output_filepath = tmp_path / "mock.pdf"
     runner = CliRunner()
     result = runner.invoke(nobubo.main, ["--il", "1", "8", "4", "--il", "34", "7", "3", "--ol", "a0", str(filepath), str(output_filepath)])
-    assert result.exit_code == 0
+    try:
+        assert result.exit_code == 0
+    except AssertionError:
+        print(result.output)
     assert pdftester.read() == ["mock_1.pdf", "mock_2.pdf"]
 
     assert pdftester.pagecount("mock_1.pdf") == 2
@@ -173,7 +203,10 @@ def test_two_overviews_reverse_a0(testdata, tmp_path, pdftester):
     output_filepath = tmp_path / "mock.pdf"
     runner = CliRunner()
     result = runner.invoke(nobubo.main, ["--il", "1", "8", "4", "--il", "34", "7", "3", "--ol", "a0", "--reverse", str(filepath), str(output_filepath)])
-    assert result.exit_code == 0
+    try:
+        assert result.exit_code == 0
+    except AssertionError:
+        print(result.output)
     assert pdftester.read() == ["mock_1.pdf", "mock_2.pdf"]
 
     assert pdftester.pagecount("mock_1.pdf") == 2


### PR DESCRIPTION
nobubo randomly failed while executing the tests, there was no clear pattern discernible. Reason might have been the construction of the random output filename of the collage.

Also, blackbox test outputs have been improved to see why the execution of nobubo fails.